### PR TITLE
Checkpoint fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,3 +28,4 @@
 
 ### 2020-12-21
 - fixed issues with trainer module caused by incorrect loss function, made trainer as extension of module class
+- fixed checkpoint issues, earlier was recording losses instead of optimizers hence fixed it.

--- a/namedtuples.py
+++ b/namedtuples.py
@@ -55,8 +55,8 @@ class BaseGANTrainer:
             self.checkpoint = tf.train.Checkpoint(
                 generator=self.generator,
                 discriminator=self.discriminator,
-                discriminator_loss=self.discriminator_loss,
-                generator_loss=self.generator_loss)
+                generator_optimizer=self.generator_optimizer,
+                discriminator_optimizer=self.discriminator_optimizer)
 
     def get_generator_loss(self, logits):
         assert self.generator_loss is not None, (


### PR DESCRIPTION
This PR will fix #2. 

Earlier loss were recorded into checkpoints and since they were none or not tractable objects hence caused the error. Now it is been resolved by recording optimizers state.